### PR TITLE
Clean up KanbnTaskPanel

### DIFF
--- a/ext-src/KanbnBoardPanel.ts
+++ b/ext-src/KanbnBoardPanel.ts
@@ -99,9 +99,6 @@ export default class KanbnBoardPanel {
       // Enable javascript in the webview
       enableScripts: true,
 
-      // Retain state even when hidden
-      retainContextWhenHidden: true,
-
       // Restrict the webview to only loading content from allowed paths
       localResourceRoots: [
         vscode.Uri.file(path.join(this._extensionPath, 'build')),

--- a/ext-src/KanbnBurndownPanel.ts
+++ b/ext-src/KanbnBurndownPanel.ts
@@ -31,9 +31,6 @@ export default class KanbnBurndownPanel {
       // Enable javascript in the webview
       enableScripts: true,
 
-      // Retain state even when hidden
-      retainContextWhenHidden: true,
-
       // Restrict the webview to only loading content from allowed paths
       localResourceRoots: [
         vscode.Uri.file(path.join(this._extensionPath, 'build')),

--- a/ext-src/KanbnTaskPanel.ts
+++ b/ext-src/KanbnTaskPanel.ts
@@ -109,9 +109,6 @@ export default class KanbnTaskPanel {
       // Enable javascript in the webview
       enableScripts: true,
 
-      // Retain state even when hidden
-      retainContextWhenHidden: true,
-
       // Restrict the webview to only loading content from allowed paths
       localResourceRoots: [
         vscode.Uri.file(path.join(this._extensionPath, 'build')),

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 import KanbnStatusBarItem from './KanbnStatusBarItem'
 import KanbnBoardPanel from './KanbnBoardPanel'
 import KanbnBurndownPanel from './KanbnBurndownPanel'
-import KanbnTaskPanel from './KanbnTaskPanel'
 import { Kanbn } from '@basementuniverse/kanbn/src/main'
 import * as fs from 'fs'
 
@@ -23,7 +22,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
         vscode.workspace.workspaceFolders[0].uri.fsPath,
         this.kanbn,
         boardLocation)
-      this.kanbnBoardPanel = KanbnBoardPanel.create(
+      this.kanbnBoardPanel = new KanbnBoardPanel(
         context.extensionPath,
         vscode.workspace.workspaceFolders[0].uri.fsPath,
         this.kanbn,
@@ -163,15 +162,8 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
       const kanbnTuple = boardCache.get(board)
       if (kanbnTuple === undefined) { return }
 
-      // If kanbn is initialised, open the task webview
-      void KanbnTaskPanel.show(
-        context.extensionPath,
-        vscode.workspace.workspaceFolders[0].uri.fsPath,
-        kanbnTuple.kanbn,
-        await kanbnTuple.kanbn.getFolderName(),
-        null,
-        null
-      )
+      // Open the task webview
+      kanbnTuple.kanbnBoardPanel.showTaskPanel(null)
     })
   )
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,46 +10,78 @@ const vscode: VSCodeApi = acquireVsCodeApi()
 const zip = (a: any[], b: any[]): Array<[any, any]> => a.map((v: any, i: number): [any, any] => [v, b[i]])
 
 function App (): JSX.Element {
-  const [type, setType] = useState('')
-  const [name, setName] = useState('')
-  const [description, setDescription] = useState('')
-  const [columns, setColumns] = useState({})
-  const [hiddenColumns, setHiddenColumns] = useState([])
-  const [startedColumns, setStartedColumns] = useState([])
-  const [completedColumns, setCompletedColumns] = useState([])
-  const [columnSorting, setColumnSorting] = useState({})
-  const [customFields, setCustomFields] = useState([])
-  const [dateFormat, setDateFormat] = useState('')
-  const [task, setTask] = useState({})
-  const [tasks, setTasks] = useState({})
-  const [columnName, setColumnName] = useState('')
-  const [columnNames, setColumnNames] = useState([] as string[])
-  const [panelUuid, setPanelUuid] = useState('')
-  const [showBurndownButton, setShowBurndownButton] = useState(false)
-  const [showSprintButton, setShowSprintButton] = useState(false)
-  const [sprints, setSprints] = useState([])
-  const [currentSprint, setCurrentSprint] = useState(null)
-  const [burndownData, setBurndownData] = useState({ series: [] })
-
+  const state = vscode.getState() ?? {
+    type: '',
+    name: '',
+    description: '',
+    columns: {},
+    hiddenColumns: [],
+    startedColumns: [],
+    completedColumns: [],
+    columnSorting: {},
+    customFields: [],
+    dateFormat: '',
+    task: {},
+    tasks: {},
+    columnName: '',
+    columnNames: [] as string[],
+    panelUuid: '',
+    showBurndownButton: false,
+    showSprintButton: false,
+    sprints: [],
+    currentSprint: null,
+    burndownData: { series: [] }
+  }
+  const [type, setType] = useState(state.type)
+  const [name, setName] = useState(state.name)
+  const [description, setDescription] = useState(state.description)
+  const [columns, setColumns] = useState(state.columns)
+  const [hiddenColumns, setHiddenColumns] = useState(state.hiddenColumns)
+  const [startedColumns, setStartedColumns] = useState(state.startedColumns)
+  const [completedColumns, setCompletedColumns] = useState(state.completedColumns)
+  const [columnSorting, setColumnSorting] = useState(state.columnSorting)
+  const [customFields, setCustomFields] = useState(state.customFields)
+  const [dateFormat, setDateFormat] = useState(state.dateFormat)
+  const [task, setTask] = useState(state.task)
+  const [tasks, setTasks] = useState(state.tasks)
+  const [columnName, setColumnName] = useState(state.columnName)
+  const [columnNames, setColumnNames] = useState(state.columnNames)
+  const [panelUuid, setPanelUuid] = useState(state.panelUuid)
+  const [showBurndownButton, setShowBurndownButton] = useState(state.showBurndownButton)
+  const [showSprintButton, setShowSprintButton] = useState(state.showSprintButton)
+  const [sprints, setSprints] = useState(state.sprints)
+  const [currentSprint, setCurrentSprint] = useState(state.currentSprint)
+  const [burndownData, setBurndownData] = useState(state.burndownData)
   const processMessage = useCallback(event => {
     const tasks = Object.fromEntries((event.data.tasks ?? []).map(task => [task.id, task]))
     switch (event.data.type) {
       case 'index': {
         setName(event.data.index.name)
+        state.name = event.data.index.name
         setDescription(event.data.index.description)
-        setColumns(Object.fromEntries(
+        state.description = event.data.index.description
+        const columns = Object.fromEntries(
           zip(
             Object.keys(event.data.index.columns),
             Object.values(event.data.index.columns).map(column => (column as string[]).map(taskId => tasks[taskId]))
           )
-        ))
+        )
+        setColumns(columns)
+        state.columns = columns
         setHiddenColumns(event.data.hiddenColumns)
+        state.hiddenColumns = event.data.hiddenColumns
         setStartedColumns(event.data.startedColumns)
+        state.startedColumns = event.data.startedColumns
         setCompletedColumns(event.data.completedColumns)
+        state.completedColumns = event.data.completedColumns
         setColumnSorting(event.data.columnSorting)
+        state.columnSorting = event.data.columnSorting
         setCustomFields(event.data.customFields)
+        state.customFields = event.data.customFields
         setShowBurndownButton(event.data.showBurndownButton)
+        state.showBurndownButton = event.data.showBurndownButton
         setShowSprintButton(event.data.showSprintButton)
+        state.showSprintButton = event.data.showSprintButton
 
         // Get current sprint
         let sprint = null
@@ -57,31 +89,47 @@ function App (): JSX.Element {
           sprint = event.data.index.options.sprints[event.data.index.options.sprints.length - 1]
         }
         setCurrentSprint(sprint)
+        state.currentSprint = sprint
         break
       }
 
       case 'task':
         setTask(event.data.task)
+        state.task = event.data.task
         setTasks(tasks)
+        state.tasks = tasks
         setColumnName(event.data.columnName)
+        state.columnName = event.data.columnName
         setColumnNames(Object.keys(event.data.index.columns))
+        state.columnNames = Object.keys(event.data.index.columns)
         setCustomFields(event.data.customFields)
+        state.customFields = event.data.customFields
         setPanelUuid(event.data.panelUuid)
+        state.panelUuid = event.data.panelUuid
         break
 
       case 'burndown':
         setName(event.data.index.name)
+        state.name = event.data.index.name
         setTasks(tasks)
+        state.tasks = tasks
         setSprints(
           'sprints' in event.data.index.options
             ? event.data.index.options.sprints
             : []
         )
+        state.sprints = 'sprints' in event.data.index.options
+          ? event.data.index.options.sprints
+          : []
         setBurndownData(event.data.burndownData)
+        state.burndownData = event.data.burndownData
         break
     }
     setType(event.data.type)
+    state.type = event.data.type
     setDateFormat(event.data.dateFormat)
+    state.dateFormat = event.data.dateFormat
+    vscode.setState(state)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
`KanbnTaskPanel` is no longer a static singleton object, instead each task gets assigned to a `KanbnTaskPanel` directly.
Also fixed some bugs associated with `retainContextWhenHidden` by using `setState` / `getState` instead. Should also improve memory usage.