### PR TITLE
Replace Formik with react-hook-form

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,9 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
   "typescript.tsc.autoDetect": "off",
-  "eslint.validate": ["typescript", "typescriptreact"]
+  "eslint.validate": [
+    "typescript",
+    "typescriptreact"
+  ],
+  "cmake.configureOnOpen": false
 }

--- a/ext-src/KanbnTaskPanel.ts
+++ b/ext-src/KanbnTaskPanel.ts
@@ -199,14 +199,14 @@ export default class KanbnTaskPanel {
           case 'kanbn.delete':
             void vscode.window
               // TODO: remove the explicit String cast once typescript bindings for kanbn are updated
-              .showInformationMessage(`Delete task '${String(message.taskData.name)}'?`, 'Yes', 'No')
+              .showInformationMessage(`Delete task '${String((await this._kanbn.getTask(this._taskId ?? '')).name)}'?`, 'Yes', 'No')
               .then(async (value) => {
                 if (value === 'Yes') {
                   await this._kanbn.deleteTask(message.taskId, true)
                   this.dispose()
                   if (vscode.workspace.getConfiguration('kanbn').get<boolean>('showTaskNotifications') ?? true) {
                     // TODO: remove the explicit String cast once typescript bindings for kanbn are updated
-                    void vscode.window.showInformationMessage(`Deleted task '${String(message.taskData.name)}'.`)
+                    void vscode.window.showInformationMessage(`Deleted task '${String(String((await this._kanbn.getTask(this._taskId ?? '')).name))}'.`)
                   }
                 }
               })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "vscode-kanbn-boards",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-kanbn-boards",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@basementuniverse/kanbn": "git@github.com:samgiz/kanbn.git#1536b686f8b530c5eca1cd997347f250d767951c",
         "@types/vscode": "^1.74.0",
         "@vscode/test-electron": "^2.2.1",
         "dateformat": "^5.0.3",
-        "formik": "^2.2.9",
         "param-case": "^3.0.4",
         "path": "^0.12.7",
         "react": "^18.2.0",
@@ -7258,14 +7257,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -9307,29 +9298,6 @@
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formik": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
-      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://opencollective.com/formik"
-        }
-      ],
-      "dependencies": {
-        "deepmerge": "^2.1.1",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "react-fast-compare": "^2.0.1",
-        "tiny-warning": "^1.0.2",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/forwarded": {
@@ -13870,11 +13838,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -17304,11 +17267,6 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
-    "node_modules/react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
-    },
     "node_modules/react-hook-form": {
       "version": "7.43.3",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.3.tgz",
@@ -19822,11 +19780,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -27005,11 +26958,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
-    },
     "default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -28536,20 +28484,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
-    },
-    "formik": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
-      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
-      "requires": {
-        "deepmerge": "^2.1.1",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "react-fast-compare": "^2.0.1",
-        "tiny-warning": "^1.0.2",
-        "tslib": "^1.10.0"
-      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -32050,11 +31984,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -34342,11 +34271,6 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
-    "react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
-    },
     "react-hook-form": {
       "version": "7.43.3",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.3.tgz",
@@ -36293,11 +36217,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vscode-kanbn",
-  "version": "0.11.0",
+  "name": "vscode-kanbn-boards",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-kanbn",
-      "version": "0.11.0",
+      "name": "vscode-kanbn-boards",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@basementuniverse/kanbn": "git@github.com:samgiz/kanbn.git#1536b686f8b530c5eca1cd997347f250d767951c",
@@ -19,6 +19,7 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "13.1.1",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.43.3",
         "react-markdown": "^8.0.3",
         "react-syntax-highlighter": "^15.5.0",
         "react-textarea-autosize": "^8.4.0",
@@ -17308,6 +17309,21 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
+    "node_modules/react-hook-form": {
+      "version": "7.43.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.3.tgz",
+      "integrity": "sha512-LV6Fixh+hirrl6dXbM78aB6n//82aKbsNbcofF3wc6nx1UJLu3Jj/gsg1E5C9iISnLX+du8VTUyBUz2aCy+H7w==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -34330,6 +34346,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-hook-form": {
+      "version": "7.43.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.3.tgz",
+      "integrity": "sha512-LV6Fixh+hirrl6dXbM78aB6n//82aKbsNbcofF3wc6nx1UJLu3Jj/gsg1E5C9iISnLX+du8VTUyBUz2aCy+H7w==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "13.1.1",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.43.3",
     "react-markdown": "^8.0.3",
     "react-syntax-highlighter": "^15.5.0",
     "react-textarea-autosize": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "@types/vscode": "^1.74.0",
     "@vscode/test-electron": "^2.2.1",
     "dateformat": "^5.0.3",
-    "formik": "^2.2.9",
     "param-case": "^3.0.4",
     "path": "^0.12.7",
     "react": "^18.2.0",

--- a/src/KanbnTask.d.ts
+++ b/src/KanbnTask.d.ts
@@ -1,6 +1,5 @@
 // Note that Date properties will be converted to strings (ISO) when a task is serialized and passed as a prop
 declare interface KanbnTask {
-  uuid?: string
   id: string
   name: string
   description: string

--- a/src/TaskEditor.tsx
+++ b/src/TaskEditor.tsx
@@ -1,45 +1,47 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { useEffect, useState, useCallback } from 'react'
-import { Formik, Form, Field, ErrorMessage, FieldArray } from 'formik'
+// import { Formik, Form, Field, ErrorMessage, FieldArray } from 'formik'
+import { useForm } from 'react-hook-form'
 import formatDate from 'dateformat'
 import vscode from './vscode'
 import { paramCase } from '@basementuniverse/kanbn/src/utility'
 import ReactMarkdown from 'react-markdown'
-import TextareaAutosize from 'react-textarea-autosize'
+// import TextareaAutosize from 'react-textarea-autosize'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import 'katex/dist/katex.min.css'
 
-interface KanbnTaskValidationOutput {
-  name: string
-  metadata: {
-    tags: string[]
-    created?: string | Date | undefined
-    updated?: string | null | undefined
-    started?: string
-    due?: string
-    completed?: string
-    assigned?: string | undefined
-  }
-  subTasks: Array<{
-    text: string
-  }>
-  comments: Array<{
-    author?: string
-    date?: string
-    text: string
-  }>
-}
+// interface KanbnTaskValidationOutput {
+//   name: string
+//   metadata: {
+//     tags: string[]
+//     created?: string | Date | undefined
+//     updated?: string | null | undefined
+//     started?: string
+//     due?: string
+//     completed?: string
+//     assigned?: string | undefined
+//   }
+//   subTasks: Array<{
+//     text: string
+//   }>
+//   comments: Array<{
+//     author?: string
+//     date?: string
+//     text: string
+//   }>
+// }
 
-interface KanbnTaskValidationInput extends KanbnTaskValidationOutput {
-  description: any
-  relations: any
-  progress: number | undefined
-  id: string
-  column: string
-}
+// interface KanbnTaskValidationInput extends KanbnTaskValidationOutput {
+//   description: any
+//   relations: any
+//   progress: number | undefined
+//   id: string
+//   column: string
+// }
 
 const components = {
   code ({ node, inline, className, children, ...props }) {
@@ -71,7 +73,7 @@ const Markdown = (props): JSX.Element => (<ReactMarkdown {...{
 }} />)
 
 const TaskEditor = (): JSX.Element => {
-  const [state, setState] = useState(vscode.getState() ?? {
+  const [state, setState] = useState({
     type: '',
     name: '',
     customFields: [],
@@ -81,8 +83,8 @@ const TaskEditor = (): JSX.Element => {
     columnName: '',
     columnNames: [] as string[],
     sprints: [],
-    taskData: {
-      id: '',
+    taskData: vscode.getState() ?? {
+      initialised: false,
       name: '',
       description: '',
       column: '',
@@ -105,6 +107,7 @@ const TaskEditor = (): JSX.Element => {
   })
 
   const processMessage = useCallback(event => {
+    console.log('Received message from webview', event.data)
     const newState: any = {}
     const tasks = Object.fromEntries((event.data.tasks ?? []).map(task => [task.id, task]))
     newState.task = event.data.task
@@ -118,7 +121,7 @@ const TaskEditor = (): JSX.Element => {
     newState.editingComment = state.editingComment
     const task = newState.task
     newState.taskData = {
-      id: task?.id ?? '',
+      initialised: true,
       name: task?.name ?? '',
       description: task?.description ?? '',
       column: newState.columnName,
@@ -147,7 +150,9 @@ const TaskEditor = (): JSX.Element => {
       subTasks: task?.subTasks ?? [],
       comments: task?.comments ?? []
     }
-    vscode.setState(newState)
+    if (!state.taskData.initialised) {
+      vscode.setState(newState.taskData)
+    }
     setState(newState)
   }, [])
 
@@ -156,46 +161,34 @@ const TaskEditor = (): JSX.Element => {
     return () => {
       window.removeEventListener('message', processMessage)
     }
-  }, [])
+  })
 
-  const setTaskData = (taskData): void => {
-    const newState = { ...state, taskData }
-    setState(newState)
-    vscode.setState(newState)
-  }
   const editing = state.task !== null
   const setEditingDescription = (editingDescription): void => {
     const newState = { ...state, editingDescription }
     setState(newState)
-    vscode.setState(newState)
   }
   const setEditingComment = (editingComment): void => {
     const newState = { ...state, editingComment }
     setState(newState)
-    vscode.setState(newState)
   }
 
   // Called when the name field is changed
-  const handleUpdateName = ({ target: { value } }, values): void => {
-    const id = paramCase(value)
-
-    // Update the id preview
-    setTaskData({
-      ...state.taskData,
-      id,
-      name: value
-    })
-
-    // Update values
-    values.id = id
-  }
+  // const handleFormValuesChange = (e, values): void => {
+  //   console.log(e)
+  //   console.log(values)
+  //   const newState = { ...state, taskData: values }
+  //   setState(newState)
+  //   vscode.setState(values)
+  // }
 
   // Called when the form is submitted
-  const handleSubmit = (values, setSubmitting, resetForm): void => {
+  const handleTaskSave = (values): void => {
+    const newValues = { ...values, id: paramCase(values.name) }
     if (editing) {
       vscode.postMessage({
         command: 'kanbn.update',
-        taskId: state.task?.id,
+        taskId: newValues.id,
         taskData: values,
         customFields: state.customFields
       })
@@ -206,26 +199,21 @@ const TaskEditor = (): JSX.Element => {
         customFields: state.customFields
       })
     }
-    setTaskData(values)
-    resetForm({ values })
-    setSubmitting(false)
   }
 
   // Called when the delete task button is clicked
-  const handleRemoveTask = (values): void => {
+  const handleRemoveTask = (): void => {
     vscode.postMessage({
       command: 'kanbn.delete',
-      taskId: state.task?.id,
-      taskData: values
+      taskId: state.task && paramCase((state.task as any).name ?? '')
     })
   }
 
   // Called when the archive task button is clicked
-  const handleArchiveTask = (values): void => {
+  const handleArchiveTask = (): void => {
     vscode.postMessage({
       command: 'kanbn.archive',
-      taskId: state.task?.id,
-      taskData: values
+      taskId: state.task && paramCase((state.task as any).name ?? '')
     })
   }
 
@@ -238,59 +226,59 @@ const TaskEditor = (): JSX.Element => {
   }
 
   // Validate form data
-  const validate = (values: KanbnTaskValidationInput): KanbnTaskValidationOutput | {} => {
-    let hasErrors = false
-    const errors: KanbnTaskValidationOutput = {
-      name: '',
-      metadata: {
-        tags: []
-      },
-      subTasks: [],
-      comments: []
-    }
+  // const validate = (values: KanbnTaskValidationInput): KanbnTaskValidationOutput | {} => {
+  //   let hasErrors = false
+  //   const errors: KanbnTaskValidationOutput = {
+  //     name: '',
+  //     metadata: {
+  //       tags: []
+  //     },
+  //     subTasks: [],
+  //     comments: []
+  //   }
 
-    // Task name cannot be empty
-    if (values.id === '') {
-      errors.name = 'Task name is required.'
-      hasErrors = true
-    }
+  //   // Task name cannot be empty
+  //   if (values.name === '') {
+  //     errors.name = 'Task name is required.'
+  //     hasErrors = true
+  //   }
 
-    // Check if the id is already in use
-    if (state.taskData.id in state.tasks && state.tasks[state.taskData.id].uuid !== ((state.task != null) ? state.task.uuid : '')) {
-      errors.name = 'There is already a task with the same name or id.'
-      hasErrors = true
-    }
+  //   // Check if the id is already in use
+  //   if (paramCase(state.taskData.name ?? '') in state.tasks && state.tasks[paramCase(state.taskData.name ?? '')].uuid !== ((state.task != null) ? (state.task as any).uuid : '')) {
+  //     errors.name = 'There is already a task with the same name or id.'
+  //     hasErrors = true
+  //   }
 
-    // Tag names cannot be empty
-    for (let i = 0; i < values.metadata.tags.length; i++) {
-      if (values.metadata.tags[i] === '') {
-        errors.metadata.tags[i] = 'Tag cannot be empty.'
-        hasErrors = true
-      }
-    }
+  //   // Tag names cannot be empty
+  //   for (let i = 0; i < values.metadata.tags.length; i++) {
+  //     if (values.metadata.tags[i] === '') {
+  //       errors.metadata.tags[i] = 'Tag cannot be empty.'
+  //       hasErrors = true
+  //     }
+  //   }
 
-    // Sub-tasks text cannot be empty
-    for (let i = 0; i < values.subTasks.length; i++) {
-      if (values.subTasks[i].text === '') {
-        errors.subTasks[i] = {
-          text: 'Sub-task text cannot be empty.'
-        }
-        hasErrors = true
-      }
-    }
+  //   // Sub-tasks text cannot be empty
+  //   for (let i = 0; i < values.subTasks.length; i++) {
+  //     if (values.subTasks[i].text === '') {
+  //       errors.subTasks[i] = {
+  //         text: 'Sub-task text cannot be empty.'
+  //       }
+  //       hasErrors = true
+  //     }
+  //   }
 
-    // Comments text cannot be empty
-    for (let i = 0; i < values.comments.length; i++) {
-      if (values.comments[i].text === '') {
-        errors.comments[i] = {
-          text: 'Comment text cannot be empty.'
-        }
-        hasErrors = true
-      }
-    }
+  //   // Comments text cannot be empty
+  //   for (let i = 0; i < values.comments.length; i++) {
+  //     if (values.comments[i].text === '') {
+  //       errors.comments[i] = {
+  //         text: 'Comment text cannot be empty.'
+  //       }
+  //       hasErrors = true
+  //     }
+  //   }
 
-    return hasErrors ? errors : {}
-  }
+  //   return hasErrors ? errors : {}
+  // }
 
   useEffect(() => {
     vscode.postMessage({
@@ -298,26 +286,32 @@ const TaskEditor = (): JSX.Element => {
     })
   }, [])
 
+  const { register, handleSubmit, formState: { isDirty, isSubmitting } } = useForm()
+  const values = state.taskData
   return (
     <div className="kanbn-task-editor">
-      <Formik
-        initialValues={state.taskData}
+      <form onSubmit={handleSubmit(handleTaskSave)}>
+        {/* initialValues={state.taskData}
         validate={validate}
         enableReinitialize
         onSubmit={(values, { setSubmitting, resetForm }) => {
           handleSubmit(values, setSubmitting, resetForm)
-        }}
-      >
-        {({
+        }} */}
+      {/* > */}
+        {/* {({
           dirty,
           values,
           handleChange,
           isSubmitting
-        }) => (
-          <Form>
+        }) => ( */}
+          {/* <Form
+          onChange={(e) => {
+            handleChange(e)
+            handleFormValuesChange(e, values)
+          }}> */}
             <h1 className="kanbn-task-editor-title">
               {editing ? 'Update task' : 'Create new task'}
-              {dirty && <span className="kanbn-task-editor-dirty">*</span>}
+              {isDirty && <span className="kanbn-task-editor-dirty">*</span>}
             </h1>
             <div className="kanbn-task-editor-buttons kanbn-task-editor-main-buttons">
               {editing && <button
@@ -325,7 +319,7 @@ const TaskEditor = (): JSX.Element => {
                 className="kanbn-task-editor-button kanbn-task-editor-button-delete"
                 title="Delete task"
                 onClick={() => {
-                  handleRemoveTask(values)
+                  handleRemoveTask()
                 }}
               >
                 <i className="codicon codicon-trash"></i>Delete
@@ -335,7 +329,7 @@ const TaskEditor = (): JSX.Element => {
                 className="kanbn-task-editor-button kanbn-task-editor-button-archive"
                 title="Archive task"
                 onClick={() => {
-                  handleArchiveTask(values)
+                  handleArchiveTask()
                 }}
               >
                 <i className="codicon codicon-archive"></i>Archive
@@ -352,8 +346,8 @@ const TaskEditor = (): JSX.Element => {
             {editing && <span className="kanbn-task-editor-dates">
               {
                 [
-                  'created' in state.task.metadata ? `Created ${formatDate(state.task.metadata.created, state.dateFormat)}` : null,
-                  'updated' in state.task.metadata ? `Updated ${formatDate(state.task.metadata.updated, state.dateFormat)}` : null
+                  'created' in (state.task as any).metadata ? `Created ${formatDate((state.task as any).metadata.created, state.dateFormat)}` : null,
+                  'updated' in (state.task as any).metadata ? `Updated ${formatDate((state.task as any).metadata.updated, state.dateFormat)}` : null
                 ].filter(i => i).join(', ')
               }
             </span>}
@@ -362,22 +356,19 @@ const TaskEditor = (): JSX.Element => {
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-name">
                   <label className="kanbn-task-editor-field-label">
                     <p>Name</p>
-                    <Field
+                    <input
+                      {...register('name')}
                       className="kanbn-task-editor-field-input"
-                      name="name"
+                      // name="name"
                       placeholder="Name"
-                      onChange={e => {
-                        handleChange(e)
-                        handleUpdateName(e, values)
-                      }}
                     />
                   </label>
-                  <div className="kanbn-task-editor-id">{state.taskData?.id ?? ''}</div>
-                  <ErrorMessage
+                  <div className="kanbn-task-editor-id">{(state.taskData && paramCase(state.taskData.name ?? ''))}</div>
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="name"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-description">
                   <label
@@ -395,59 +386,62 @@ const TaskEditor = (): JSX.Element => {
                     }}
                   >
                     {
-                      state.editingDescription === true
+                      state.editingDescription
                         ? <><i className="codicon codicon-preview"></i> Preview</>
                         : <><i className="codicon codicon-edit"></i> Edit</>
                     }
                   </button>
                   {
                     state.editingDescription
-                      ? <Field
+                      ? <input
+                        {...register('description')}
                         className="kanbn-task-editor-field-textarea"
                         id="description-input"
-                        as={TextareaAutosize}
-                        name="description"
+                        // as={TextareaAutosize}
+                        // name="description"
                       />
                       : <Markdown className="kanbn-task-editor-description-preview">
-                        {values.description}
+                        {state.taskData?.description ?? ''}
                       </Markdown>
                   }
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="description"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-subtasks">
                   <h2 className="kanbn-task-editor-title">Sub-tasks</h2>
-                  <FieldArray name="subTasks">
+                  {/* <FieldArray name="subTasks"> */}<>
                     {({ insert, remove, push }) => (
                       <div>
                         {values.subTasks.length > 0 && values.subTasks.map((subTask, index) => (
                           <div className="kanbn-task-editor-row kanbn-task-editor-row-subtask" key={index}>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-subtask-completed">
-                              <Field
+                              <input
+                                {...register(`subTasks.${index}.completed`)}
                                 className="kanbn-task-editor-field-checkbox"
                                 type="checkbox"
-                                name={`subTasks.${index}.completed`}
+                                // name={`subTasks.${index}.completed`}
                               />
-                              <ErrorMessage
+                              {/* <ErrorMessage
                                 className="kanbn-task-editor-field-errors"
                                 component="div"
                                 name={`subTasks.${index}.completed`}
-                              />
+                              /> */}
                             </div>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-subtask-text">
-                              <Field
+                              <input
+                                {...register(`subTasks.${index}.text`)}
                                 className="kanbn-task-editor-field-input"
-                                name={`subTasks.${index}.text`}
+                                // name={`subTasks.${index}.text`}
                                 placeholder="Sub-task text"
                               />
-                              <ErrorMessage
+                              {/* <ErrorMessage
                                 className="kanbn-task-editor-field-errors"
                                 component="div"
                                 name={`subTasks.${index}.text`}
-                              />
+                              /> */}
                             </div>
                             <div className="kanbn-task-editor-column kanbn-task-editor-column-buttons">
                               <button
@@ -473,40 +467,42 @@ const TaskEditor = (): JSX.Element => {
                         </div>
                       </div>
                     )}
-                  </FieldArray>
+                  {/* </FieldArray> */}</>
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-relations">
                   <h2 className="kanbn-task-editor-title">Relations</h2>
-                  <FieldArray name="relations">
+                  {/* <FieldArray name="relations"> */}<>
                     {({ insert, remove, push }) => (
                       <div>
                         {values.relations.length > 0 && values.relations.map((relation, index) => (
                           <div className="kanbn-task-editor-row kanbn-task-editor-row-relation" key={index}>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-relation-type">
-                              <Field
+                              <input
+                                {...register(`relations.${index}.type`)}
                                 className="kanbn-task-editor-field-input"
-                                name={`relations.${index}.type`}
+                                // name={`relations.${index}.type`}
                                 placeholder="Relation type"
                               />
-                              <ErrorMessage
+                              {/* <ErrorMessage
                                 className="kanbn-task-editor-field-errors"
                                 component="div"
                                 name={`relations.${index}.type`}
-                              />
+                              /> */}
                             </div>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-relation-task">
-                              <Field
+                              <select
+                                {...register(`relations.${index}.task`)}
                                 className="kanbn-task-editor-field-select"
-                                as="select"
-                                name={`relations.${index}.task`}
+                                // as="select"
+                                // name={`relations.${index}.task`}
                               >
                                 {Object.keys(state.tasks).map(t => <option key={state.tasks[t].id} value={t}>{t}</option>)}
-                              </Field>
-                              <ErrorMessage
+                              </select>
+                              {/* <ErrorMessage
                                 className="kanbn-task-editor-field-errors"
                                 component="div"
                                 name={`relations.${index}.task`}
-                              />
+                              /> */}
                             </div>
                             <div className="kanbn-task-editor-column kanbn-task-editor-column-buttons">
                               <button
@@ -532,11 +528,11 @@ const TaskEditor = (): JSX.Element => {
                         </div>
                       </div>
                     )}
-                  </FieldArray>
+                  {/* </FieldArray> */}</>
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-comments">
                   <h2 className="kanbn-task-editor-title">Comments</h2>
-                  <FieldArray name="comments">
+                  {/* <FieldArray name="comments"> */}<>
                     {({ insert, remove, push }) => (
                       <div>
                         {values.comments.length > 0 && values.comments.map((comment, index) => (
@@ -546,16 +542,17 @@ const TaskEditor = (): JSX.Element => {
                                 {
                                   state.editingComment === index
                                     ? <>
-                                      <Field
+                                      <input
+                                        {...register(`comments.${index}.author`)}
                                         className="kanbn-task-editor-field-input"
-                                        name={`comments.${index}.author`}
+                                        // name={`comments.${index}.author`}
                                         placeholder="Comment author"
                                       />
-                                      <ErrorMessage
+                                      {/* <ErrorMessage
                                         className="kanbn-task-editor-field-errors"
                                         component="div"
                                         name={`comments.${index}.author`}
-                                      />
+                                      /> */}
                                     </>
                                     : <div className="kanbn-task-editor-field-comment-author-value">
                                       <i className="codicon codicon-account"></i>
@@ -596,16 +593,17 @@ const TaskEditor = (): JSX.Element => {
                                 {
                                   state.editingComment === index
                                     ? <>
-                                      <Field
+                                      <input
+                                        {...register(`comments.${index}.text`)}
                                         className="kanbn-task-editor-field-textarea"
-                                        as={TextareaAutosize}
-                                        name={`comments.${index}.text`}
+                                        // as={TextareaAutosize}
+                                        // name={`comments.${index}.text`}
                                       />
-                                      <ErrorMessage
+                                      {/* <ErrorMessage
                                         className="kanbn-task-editor-field-errors"
                                         component="div"
                                         name={`comments.${index}.text`}
-                                      />
+                                      /> */}
                                     </>
                                     : <Markdown className="kanbn-task-editor-comment-text">
                                       {comment.text}
@@ -630,97 +628,103 @@ const TaskEditor = (): JSX.Element => {
                         </div>
                       </div>
                     )}
-                  </FieldArray>
+                  {/* </FieldArray> */}</>
                 </div>
               </div>
               <div className="kanbn-task-editor-column-right">
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-column">
                   <label className="kanbn-task-editor-field-label">
                     <p>Column</p>
-                    <Field
+                    <select
+                      {...register('column')}
                       className="kanbn-task-editor-field-select"
-                      as="select"
-                      name="column"
+                      // as="select"
+                      // name="column"
                     >
                       {state.columnNames.map(c => <option key={c} value={c}>{c}</option>)}
-                    </Field>
+                    </select>
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="column"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-assigned">
                   <label className="kanbn-task-editor-field-label">
                     <p>Assigned to</p>
-                    <Field
+                    <input
+                      {...register('metadata.assigned')}
                       className="kanbn-task-editor-field-input"
-                      name="metadata.assigned"
+                      // name="metadata.assigned"
                       placeholder="Assigned to"
                     />
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="metadata.assigned"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-started">
                   <label className="kanbn-task-editor-field-label">
                     <p>Started date</p>
-                    <Field
+                    <input
+                      {...register('metadata.started')}
                       className="kanbn-task-editor-field-input"
                       type="date"
-                      name="metadata.started"
+                      // name="metadata.started"
                     />
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="metadata.started"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-due">
                   <label className="kanbn-task-editor-field-label">
                     <p>Due date</p>
-                    <Field
+                    <input
+                      {...register('metadata.due')}
                       className={[
                         'kanbn-task-editor-field-input',
                         checkOverdue(values) ? 'kanbn-task-overdue' : null
                       ].filter(i => i).join(' ')}
                       type="date"
-                      name="metadata.due"
+                      // name="metadata.due"
                     />
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="metadata.due"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-completed">
                   <label className="kanbn-task-editor-field-label">
                     <p>Completed date</p>
-                    <Field
+                    <input
+                      {...register('metadata.completed')}
                       className="kanbn-task-editor-field-input"
                       type="date"
-                      name="metadata.completed"
+                      // name="metadata.completed"
                     />
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="metadata.completed"
-                  />
+                  /> */}
                 </div>
                 <div className="kanbn-task-editor-field kanbn-task-editor-field-progress">
                   <label className="kanbn-task-editor-field-label">
                     <p>Progress</p>
-                    <Field
+                    <input
+                      {...register('progress')}
                       className="kanbn-task-editor-field-input"
                       type="number"
-                      name="progress"
+                      // name="progress"
                       min="0"
                       max="1"
                       step="0.05"
@@ -729,50 +733,52 @@ const TaskEditor = (): JSX.Element => {
                       width: `${Math.min(1, Math.max(0, values.progress ?? 0)) * 100}%`
                     }}></div>
                   </label>
-                  <ErrorMessage
+                  {/* <ErrorMessage
                     className="kanbn-task-editor-field-errors"
                     component="div"
                     name="progress"
-                  />
+                  /> */}
                 </div>
                 {
                   state.customFields.map(customField => (
-                    <div key={customField.name} className={[
+                    <div key={(customField as any).name} className={[
                       'kanbn-task-editor-field kanbn-task-editor-custom-field',
                       // TODO: remove the explicit String cast once typescript bindings for kanbn are updated
-                      `kanbn-task-editor-custom-field-${String(paramCase(customField.name))}`
+                      `kanbn-task-editor-custom-field-${String(paramCase((customField as any).name))}`
                     ].join(' ')}>
                       <label className="kanbn-task-editor-field-label">
-                        {customField.type === 'boolean'
+                        {(customField as any).type === 'boolean'
                           ? (
                             <>
-                              <Field
+                              <input
+                                {...register(`metadata.${(customField as any).name}`)}
                                 className="kanbn-task-editor-field-input kanbn-task-editor-custom-checkbox"
                                 type="checkbox"
-                                name={`metadata.${customField.name}`}
-                              /><p>{customField.name}</p>
+                                // name={`metadata.${(customField as any).name}`}
+                              /><p>{(customField as any).name}</p>
                             </>
                             )
                           : (
                             <>
-                              <p>{customField.name}</p>
-                              <Field
+                              <p>{(customField as any).name}</p>
+                              <input
+                                {...register(`metadata.${(customField as any).name}`)}
                                 className="kanbn-task-editor-field-input"
                                 type={{
                                   date: 'date',
                                   number: 'number',
                                   string: 'text'
-                                }[customField.type]}
-                                name={`metadata.${customField.name}`}
+                                }[(customField as any).type]}
+                                // name={`metadata.${(customField as any).name}`}
                               />
                             </>
                             )}
                       </label>
-                      <ErrorMessage
+                      {/* <ErrorMessage
                         className="kanbn-task-editor-field-errors"
                         component="div"
-                        name={`metadata.${customField.name}`}
-                      />
+                        name={`metadata.${(customField as any).name}`}
+                      /> */}
                     </div>
                   ))
                 }
@@ -780,7 +786,7 @@ const TaskEditor = (): JSX.Element => {
                   <label className="kanbn-task-editor-field-label">
                     <p>Tags</p>
                   </label>
-                  <FieldArray name="metadata.tags">
+                  {/* <FieldArray name="metadata.tags"> */}<>
                     {({ insert, remove, push }) => (
                       <div>
                         {(
@@ -789,9 +795,10 @@ const TaskEditor = (): JSX.Element => {
                         ) && values.metadata.tags.map((tag, index) => (
                           <div className="kanbn-task-editor-row kanbn-task-editor-row-tag" key={index}>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-tag">
-                              <Field
+                              <input
+                                {...register(`metadata.tags.${index}`)}
                                 className="kanbn-task-editor-field-input"
-                                name={`metadata.tags.${index}`}
+                                // name={`metadata.tags.${index}`}
                                 placeholder="Tag name"
                               />
                               <div
@@ -801,11 +808,11 @@ const TaskEditor = (): JSX.Element => {
                                   `kanbn-task-tag-${String(paramCase(values.metadata.tags[index]))}`
                                 ].join(' ')}
                               ></div>
-                              <ErrorMessage
+                              {/* <ErrorMessage
                                 className="kanbn-task-editor-field-errors"
                                 component="div"
                                 name={`metadata.tags.${index}`}
-                              />
+                              /> */}
                             </div>
                             <div className="kanbn-task-editor-column kanbn-task-editor-column-buttons">
                               <button
@@ -831,13 +838,13 @@ const TaskEditor = (): JSX.Element => {
                         </div>
                       </div>
                     )}
-                  </FieldArray>
+                  {/* </FieldArray> */}</>
                 </div>
               </div>
             </div>
-          </Form>
-        )}
-      </Formik>
+          {/* </Form> */}
+        {/* )} */}
+      </form>
     </div>
   )
 }

--- a/src/TaskEditor.tsx
+++ b/src/TaskEditor.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { useEffect, useState, useCallback } from 'react'
-// import { Formik, Form, Field, ErrorMessage, FieldArray } from 'formik'
 import { useForm } from 'react-hook-form'
 import formatDate from 'dateformat'
 import vscode from './vscode'
@@ -13,35 +12,6 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import 'katex/dist/katex.min.css'
-
-// interface KanbnTaskValidationOutput {
-//   name: string
-//   metadata: {
-//     tags: string[]
-//     created?: string | Date | undefined
-//     updated?: string | null | undefined
-//     started?: string
-//     due?: string
-//     completed?: string
-//     assigned?: string | undefined
-//   }
-//   subTasks: Array<{
-//     text: string
-//   }>
-//   comments: Array<{
-//     author?: string
-//     date?: string
-//     text: string
-//   }>
-// }
-
-// interface KanbnTaskValidationInput extends KanbnTaskValidationOutput {
-//   description: any
-//   relations: any
-//   progress: number | undefined
-//   id: string
-//   column: string
-// }
 
 const components = {
   code ({ node, inline, className, children, ...props }) {
@@ -226,59 +196,10 @@ const TaskEditor = (): JSX.Element => {
   }
 
   // Validate form data
-  // const validate = (values: KanbnTaskValidationInput): KanbnTaskValidationOutput | {} => {
-  //   let hasErrors = false
-  //   const errors: KanbnTaskValidationOutput = {
-  //     name: '',
-  //     metadata: {
-  //       tags: []
-  //     },
-  //     subTasks: [],
-  //     comments: []
-  //   }
-
-  //   // Task name cannot be empty
-  //   if (values.name === '') {
-  //     errors.name = 'Task name is required.'
-  //     hasErrors = true
-  //   }
-
-  //   // Check if the id is already in use
-  //   if (paramCase(state.taskData.name ?? '') in state.tasks && state.tasks[paramCase(state.taskData.name ?? '')].uuid !== ((state.task != null) ? (state.task as any).uuid : '')) {
-  //     errors.name = 'There is already a task with the same name or id.'
-  //     hasErrors = true
-  //   }
-
-  //   // Tag names cannot be empty
-  //   for (let i = 0; i < values.metadata.tags.length; i++) {
-  //     if (values.metadata.tags[i] === '') {
-  //       errors.metadata.tags[i] = 'Tag cannot be empty.'
-  //       hasErrors = true
-  //     }
-  //   }
-
-  //   // Sub-tasks text cannot be empty
-  //   for (let i = 0; i < values.subTasks.length; i++) {
-  //     if (values.subTasks[i].text === '') {
-  //       errors.subTasks[i] = {
-  //         text: 'Sub-task text cannot be empty.'
-  //       }
-  //       hasErrors = true
-  //     }
-  //   }
-
-  //   // Comments text cannot be empty
-  //   for (let i = 0; i < values.comments.length; i++) {
-  //     if (values.comments[i].text === '') {
-  //       errors.comments[i] = {
-  //         text: 'Comment text cannot be empty.'
-  //       }
-  //       hasErrors = true
-  //     }
-  //   }
-
-  //   return hasErrors ? errors : {}
-  // }
+  const validateName = (name: string): boolean => {
+    if (paramCase(name) in state.tasks && (state.tasks[paramCase(name)].uuid !== (state.task as any)?.uuid ?? '')) { return false }
+    return true
+  }
 
   useEffect(() => {
     vscode.postMessage({
@@ -292,7 +213,6 @@ const TaskEditor = (): JSX.Element => {
     <div className="kanbn-task-editor">
       <form onSubmit={handleSubmit(handleTaskSave)}>
         {/* initialValues={state.taskData}
-        validate={validate}
         enableReinitialize
         onSubmit={(values, { setSubmitting, resetForm }) => {
           handleSubmit(values, setSubmitting, resetForm)
@@ -357,9 +277,8 @@ const TaskEditor = (): JSX.Element => {
                   <label className="kanbn-task-editor-field-label">
                     <p>Name</p>
                     <input
-                      {...register('name')}
+                      {...register('name', { required: true, validate: validateName })}
                       className="kanbn-task-editor-field-input"
-                      // name="name"
                       placeholder="Name"
                     />
                   </label>
@@ -419,7 +338,7 @@ const TaskEditor = (): JSX.Element => {
                           <div className="kanbn-task-editor-row kanbn-task-editor-row-subtask" key={index}>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-subtask-completed">
                               <input
-                                {...register(`subTasks.${index}.completed`)}
+                                {...register(`subTasks.${index}.completed`, { required: true })}
                                 className="kanbn-task-editor-field-checkbox"
                                 type="checkbox"
                                 // name={`subTasks.${index}.completed`}
@@ -543,7 +462,7 @@ const TaskEditor = (): JSX.Element => {
                                   state.editingComment === index
                                     ? <>
                                       <input
-                                        {...register(`comments.${index}.author`)}
+                                        {...register(`comments.${index}.author`, { required: true })}
                                         className="kanbn-task-editor-field-input"
                                         // name={`comments.${index}.author`}
                                         placeholder="Comment author"
@@ -796,7 +715,7 @@ const TaskEditor = (): JSX.Element => {
                           <div className="kanbn-task-editor-row kanbn-task-editor-row-tag" key={index}>
                             <div className="kanbn-task-editor-column kanbn-task-editor-field-tag">
                               <input
-                                {...register(`metadata.tags.${index}`)}
+                                {...register(`metadata.tags.${index}`, { required: true })}
                                 className="kanbn-task-editor-field-input"
                                 // name={`metadata.tags.${index}`}
                                 placeholder="Tag name"


### PR DESCRIPTION
Replaces `Formik` with the more modern and lightweight `react-hook-form` library. This has simplified the code for TaskEditor significantly and allowed me to easier add changes required to save the current state of the form when it is hidden. Fixes #4.

Additionally revamped some of the form elements. `Edit` buttons no longer exist; instead to edit a comment or a description (or some other input element that uses markdown) simply click on the text field and you'll automatically enter editing mode. Click away and you'll see the rendered markdown.