### PR TITLE
Rename kanbn.board to kanbn.openBoard in KanbnStatusBarItem.ts.

### DIFF
--- a/ext-src/KanbnStatusBarItem.ts
+++ b/ext-src/KanbnStatusBarItem.ts
@@ -47,7 +47,7 @@ export default class KanbnStatusBarItem {
       }
       this._statusBarItem.text = text.join(' ')
       this._statusBarItem.tooltip = tooltip.join('\n')
-      this._statusBarItem.command = 'kanbn.board'
+      this._statusBarItem.command = 'kanbn.openBoard'
       this._statusBarItem.show()
     } else {
       this._statusBarItem.text = '$(project)'


### PR DESCRIPTION
The `kanbn.board` command no longer exists and the new equivalent is `kanbn.openBoard`. Now pressing on the kanbn icons at the bottom of VSCode lists the available boards to choose and open.

Fixes #5.