### PR TITLE
Fix button style when user is in light theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -124,13 +124,14 @@ Board styles
     float: right;
     outline: none;
     border: 1px transparent solid;
-    background-color: transparent;
+    background-color: var(--vscode-button-hoverBackground);
     color: var(--vscode-button-foreground);
     padding: 2px;
     height: 16px;
     width: 16px;
     margin-right: 8px;
     border-radius: 1px;
+    cursor: pointer;
 }
 
 .kanbn-column-button .codicon {


### PR DESCRIPTION
The button is not visible when user is in light theme, just like these
<img width="1085" alt="image" src="https://github.com/samgiz/vscode-kanbn/assets/25007230/09032f15-9962-4e3b-a984-547956a10f78">
I have fixed these issue, and below are the behavior when user is in dark or light theme
**light theme**
<img width="964" alt="image" src="https://github.com/samgiz/vscode-kanbn/assets/25007230/9e73a3f4-aafc-4f58-8c48-5a922729b233">
**dark theme**
<img width="967" alt="image" src="https://github.com/samgiz/vscode-kanbn/assets/25007230/212860a2-4ae0-478d-b615-3e4810810b13">

